### PR TITLE
Fixed shader compilation error on RDNA

### DIFF
--- a/shaders/post/ToneMapping.comp
+++ b/shaders/post/ToneMapping.comp
@@ -7,7 +7,7 @@ layout(local_size_x = 16, local_size_y = 16) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
 shared uint shared_lumHistogram[256];
-shared uint shared_topBinSum = 0u;
+shared uint shared_topBinSum;
 
 layout(rgba16f) restrict uniform image2D uimg_main;
 layout(rgba16f) readonly uniform image2D uimg_temp1;


### PR DESCRIPTION
Compilation error on RDNA graphics card

Details:
composite61.csh: composite61.csh: ERROR: 0:561: 'shared' : initializer can only be a null initializer ('{}') 
ERROR: 1 compilation errors.  No code generated.